### PR TITLE
Fix PHP7 warning for undefined constant

### DIFF
--- a/Upload/inc/plugins/ougc_agi.php
+++ b/Upload/inc/plugins/ougc_agi.php
@@ -39,40 +39,43 @@ if(defined('IN_ADMINCP'))
 }
 else
 {
-	switch(THIS_SCRIPT)
+	if (defined('THIS_SCRIPT'))
 	{
-		case 'showthread.php':
-		case 'private.php':
-		case 'newthread.php':
-		case 'newreply.php':
-		case 'editpost.php':
-		case 'announcements.php':
-		case 'member.php':
-			global $cache, $templatelist;
+		switch(THIS_SCRIPT)
+		{
+			case 'showthread.php':
+			case 'private.php':
+			case 'newthread.php':
+			case 'newreply.php':
+			case 'editpost.php':
+			case 'announcements.php':
+			case 'member.php':
+				global $cache, $templatelist;
 
-			$plugins->add_hook('postbit', 'ougc_agi_run');
-			$plugins->add_hook('postbit_pm', 'ougc_agi_run');
-			$plugins->add_hook('postbit_prev', 'ougc_agi_run');
-			$plugins->add_hook('postbit_announcement', 'ougc_agi_run');
-			$plugins->add_hook('member_profile_end', 'ougc_agi_run');
+				$plugins->add_hook('postbit', 'ougc_agi_run');
+				$plugins->add_hook('postbit_pm', 'ougc_agi_run');
+				$plugins->add_hook('postbit_prev', 'ougc_agi_run');
+				$plugins->add_hook('postbit_announcement', 'ougc_agi_run');
+				$plugins->add_hook('member_profile_end', 'ougc_agi_run');
 
-			if(!isset($templatelist))
-			{
-				$templatelist = '';
-			}
-			else
-			{
-				$templatelist .= ',';
-			}
+				if(!isset($templatelist))
+				{
+					$templatelist = '';
+				}
+				else
+				{
+					$templatelist .= ',';
+				}
 
-			$templatelist .= 'ougcagi';
+				$templatelist .= 'ougcagi';
 
-			$usergroups = $cache->read('usergroups');
-			foreach((array)$usergroups as $group)
-			{
-				$templatelist .= ',ougcagi_'.$group['gid'];
-			}
-			break;
+				$usergroups = $cache->read('usergroups');
+				foreach((array)$usergroups as $group)
+				{
+					$templatelist .= ',ougcagi_'.$group['gid'];
+				}
+				break;
+		}
 	}
 }
 


### PR DESCRIPTION
Example warning:

<error>
	<dateline>1571473908</dateline>
	<script>inc/plugins/ougc_agi.php</script>
	<line>46</line>
	<type>2</type>
	<friendly_type>Warning</friendly_type>
	<message>Use of undefined constant THIS_SCRIPT - assumed 'THIS_SCRIPT' (this will throw an Error in a future version of PHP)</message>
</error>